### PR TITLE
use OP_FALSE by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ These additional options can be passed:
 - `parentTxID: string` - For creating child nodes.
 - `parentKeyPath: string` - Can be passed when `parentTxID` is also passed to override `keyPath` of parent node.
 - `keyPath: string` - For setting the keypath manually. Default is `m/0`.
-- `safe: boolean` - Use OP_FALSE for scripts. Default is `false`.
+- `safe: boolean` - Use OP_FALSE for scripts. Default is `true`.
 - `includeKeyPath: boolean` - Write `keyPath` information to `OP_RETURN`. Defaults to `true`. Can be deactivated to manage keyPaths locally.
 
 Successfully creating nodes returns an object that contains the new nodes `address`, `id`, `txid` and used `keyPath`.

--- a/src/planter.ts
+++ b/src/planter.ts
@@ -103,7 +103,7 @@ export class Planter {
     return await TreeHugger.findAllNodes({ find }, opts);
   }
 
-  public async createNode({ data, parentTxID, parentKeyPath, keyPath, safe, includeKeyPath = true }: IOptions = {}) {
+  public async createNode({ data, parentTxID, parentKeyPath, keyPath, safe = true, includeKeyPath = true }: IOptions = {}) {
     keyPath = keyPath || getRandomKeyPath();
 
     const nodeAddress = this.xprivKey.deriveChild(keyPath).publicKey.toAddress();


### PR DESCRIPTION
After the Genesis upgrade the regular behavior is to use OP_FALSE OP_RETURN.
Otherwise the OP_RETURN script will be regarded as a hash puzzle.